### PR TITLE
iCloud sync fixes

### DIFF
--- a/2PASS/2PASS.xcodeproj/project.pbxproj
+++ b/2PASS/2PASS.xcodeproj/project.pbxproj
@@ -1834,7 +1834,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "2FAS Pass";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2650,7 +2650,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "2FAS Pass";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2690,7 +2690,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "2FAS Pass";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/2PASS/2PASS/Modules/Main/Interactor/MainModuleInteractor.swift
+++ b/2PASS/2PASS/Modules/Main/Interactor/MainModuleInteractor.swift
@@ -137,7 +137,7 @@ private extension MainModuleInteractor {
             return
         }
 
-        let cloudHasError = cloudSyncInteractor.currentState.hasError && cloudSyncInteractor.lastSuccessSyncDate != nil
+        let cloudHasError = cloudSyncInteractor.currentState.hasError
         let webdavHasError = webDAVStateInteractor.state.hasError && webDAVStateInteractor.isConnected
         
         let showErrorBadge = cloudHasError || webdavHasError

--- a/2PASS/2PASS/Modules/QuickSetup/QuickSetupPresenter.swift
+++ b/2PASS/2PASS/Modules/QuickSetup/QuickSetupPresenter.swift
@@ -126,12 +126,14 @@ final class QuickSetupPresenter {
     private func observeCloudStatusChanged() async {
         for await _ in interactor.didCloudStatusChanged {
             switch interactor.cloudState {
+            case .enabledNotAvailable(.syncNotAllowed):
+                destination = .syncNotAllowed
             case .enabledNotAvailable:
                 showVaultSyncFailure = true
             default:
                 break
             }
-            
+
             _iCloudSyncEnabled = interactor.isCloudEnabled
         }
     }

--- a/2PASS/2PASS/Modules/Root/Interactor/RootModuleInteractor.swift
+++ b/2PASS/2PASS/Modules/Root/Interactor/RootModuleInteractor.swift
@@ -168,7 +168,7 @@ extension RootModuleInteractor: RootModuleInteracting {
         guard securityInteractor.isUserLoggedIn && isUserSetUp else {
             return
         }
-        syncInteractor.synchronize()
+        syncInteractor.synchronize(fromPush: true)
     }
     
     func fetchAppNotifications() async throws -> [AppNotification] {

--- a/2PASS/2PASS/Modules/Settings/SettingsModuleInteractor.swift
+++ b/2PASS/2PASS/Modules/Settings/SettingsModuleInteractor.swift
@@ -73,7 +73,7 @@ extension SettingsModuleInteractor: SettingsModuleInteracting {
     
     var isSyncEnabled: Bool {
         switch cloudSyncInteractor.currentState {
-        case .enabled:
+        case .enabled, .enabledNotAvailable:
             return true
         default:
             break

--- a/2PASS/2PASS/Modules/Sync/SyncPresenter.swift
+++ b/2PASS/2PASS/Modules/Sync/SyncPresenter.swift
@@ -191,7 +191,6 @@ private extension CloudState.Sync {
         switch self {
         case .syncing: String(localized: .syncSyncing)
         case .synced: String(localized: .syncSynced)
-        case .outOfSync(.schemaNotSupported(let schemaVersion)): String(localized: .cloudSyncInvalidSchemaErrorMsg(Int32(schemaVersion)))
         }
     }
 }

--- a/2PASS/2PASS/Modules/Sync/SyncPresenter.swift
+++ b/2PASS/2PASS/Modules/Sync/SyncPresenter.swift
@@ -125,6 +125,10 @@ final class SyncPresenter {
             status = interactor.cloudState.description
             lastSyncDate = interactor.cloudLastSuccessSyncDate
             showUpdateAppButton = interactor.cloudState.isSchemeNotSupported
+            showUpgradePlanButton = interactor.cloudState.isSyncNotAllowed
+            if interactor.cloudState.isSyncNotAllowed {
+                destination = .syncNotAllowed
+            }
         } else if interactor.isWebDAVEnabled {
             status = WebDAVStatusFormatStyle().format(interactor.webDAVState)
             lastSyncDate = interactor.webDAVLastSyncDate
@@ -227,6 +231,7 @@ private extension CloudState.NotAvailableReason {
         case .incorrectEncryption: String(localized: .syncErrorIcloudErrorDiffrentEncryption)
         case .noAccount: String(localized: .syncErrorIcloudErrorNoAccount)
         case .restricted: String(localized: .syncErrorIcloudErrorAccessRestricted)
+        case .syncNotAllowed: String(localized: .syncErrorIcloudSyncNotAllowedDescription)
         }
     }
 }

--- a/2PASS/Backup/Cloud/CacheHandler.swift
+++ b/2PASS/Backup/Cloud/CacheHandler.swift
@@ -57,8 +57,8 @@ extension CacheHandler {
                 case .item:
                     let itemRecord = ItemRecord(record: record)
                     let id = itemRecord.itemID
-                        if let item = items.first(where: { $0.0 == id }) {
-                            if item.1 != itemRecord.modificationDate, let item = itemRecord.toRecordData(jsonDecoder: jsonDecoder) {
+                        if items.contains(where: { $0.0 == id }) {
+                            if let item = itemRecord.toRecordData(jsonDecoder: jsonDecoder) {
                                 cloudCacheStorage.updateItem(item: item.item, metadata: item.metadata)
                             }
                         } else {
@@ -69,22 +69,20 @@ extension CacheHandler {
                 case .deletedItem:
                     let deletedItemRecord = DeletedItemRecord(record: record)
                     let id = deletedItemRecord.itemID
-                    if let deleted = deletedItems.first(where: { $0.0 == id }) {
-                        if deleted.1 != deletedItemRecord.deletedAt {
-                            let deletedItem = deletedItemRecord.toRecordData()
-                            cloudCacheStorage
-                                .updateDeletedItem(
-                                    .init(
-                                        deletedItem: DeletedItemData(
-                                            itemID: deletedItem.deletedItem.itemID,
-                                            vaultID: deletedItem.deletedItem.vaultID,
-                                            kind: deletedItem.deletedItem.kind,
-                                            deletedAt: deletedItem.deletedItem.deletedAt
-                                        ),
-                                        metadata: deletedItem.metadata
-                                    )
+                    if deletedItems.contains(where: { $0.0 == id }) {
+                        let deletedItem = deletedItemRecord.toRecordData()
+                        cloudCacheStorage
+                            .updateDeletedItem(
+                                .init(
+                                    deletedItem: DeletedItemData(
+                                        itemID: deletedItem.deletedItem.itemID,
+                                        vaultID: deletedItem.deletedItem.vaultID,
+                                        kind: deletedItem.deletedItem.kind,
+                                        deletedAt: deletedItem.deletedItem.deletedAt
+                                    ),
+                                    metadata: deletedItem.metadata
                                 )
-                        }
+                            )
                     } else {
                         let deletedItem = deletedItemRecord.toRecordData()
                         cloudCacheStorage.createDeletedItem(
@@ -102,24 +100,22 @@ extension CacheHandler {
                 case .tag:
                     let tagRecord = TagRecord(record: record)
                     let tagID = tagRecord.tagID
-                    if let tag = tags.first(where: { $0.0 == tagID }) {
-                        if tag.1 != tagRecord.modificationDate {
-                            let tagItem = tagRecord.toRecordData()
-                            cloudCacheStorage
-                                .updateTagItem(
-                                    .init(
-                                        tagItem: .init(
-                                            tagID: tagItem.tagItem.tagID,
-                                            vaultID: tagItem.tagItem.vaultID,
-                                            name: tagItem.tagItem.name,
-                                            color: tagItem.tagItem.color,
-                                            position: tagItem.tagItem.position,
-                                            modificationDate: tagItem.tagItem.modificationDate
-                                        ),
-                                        metadata: tagItem.metadata
-                                    )
+                    if tags.contains(where: { $0.0 == tagID }) {
+                        let tagItem = tagRecord.toRecordData()
+                        cloudCacheStorage
+                            .updateTagItem(
+                                .init(
+                                    tagItem: .init(
+                                        tagID: tagItem.tagItem.tagID,
+                                        vaultID: tagItem.tagItem.vaultID,
+                                        name: tagItem.tagItem.name,
+                                        color: tagItem.tagItem.color,
+                                        position: tagItem.tagItem.position,
+                                        modificationDate: tagItem.tagItem.modificationDate
+                                    ),
+                                    metadata: tagItem.metadata
                                 )
-                        }
+                            )
                     } else {
                         let tagItem = tagRecord.toRecordData()
                         cloudCacheStorage.createTagItem(

--- a/2PASS/Backup/Cloud/CloudHandler.swift
+++ b/2PASS/Backup/Cloud/CloudHandler.swift
@@ -14,7 +14,7 @@ protocol CloudHandlerType: AnyObject {
     
     func setVaultID(vaultID: VaultID)
     func checkState()
-    func synchronize()
+    func synchronize(fromPush: Bool)
     func enable()
     func disable(notify: Bool)
     func clearBackup()
@@ -108,9 +108,9 @@ final class CloudHandler: CloudHandlerType {
         cloudAvailability.checkAvailability()
     }
     
-    func synchronize() {
+    func synchronize(fromPush: Bool = false) {
         guard !isClearing else { return }
-        
+
         Log("Cloud Handler -  Got Synchronize action", module: .cloudSync)
         if shouldResetState {
             Log("Cloud Handler - Reseting state", module: .cloudSync)
@@ -123,10 +123,10 @@ final class CloudHandler: CloudHandlerType {
             checkState()
         case .enabledNotAvailable:
             Log("Cloud Handler - enabled but not available state on synchronize", module: .cloudSync)
-            sync()
+            sync(fromPush: fromPush)
         case .enabled:
             Log("Cloud Handler -  is enabled - syncing", module: .cloudSync)
-            sync()
+            sync(fromPush: fromPush)
         case .disabled:
             Log("Cloud Handler -  Can't synchronize if cloud is disabled", module: .cloudSync)
         }
@@ -234,13 +234,13 @@ final class CloudHandler: CloudHandlerType {
         }
     }
     
-    private func sync() {
+    private func sync(fromPush: Bool = false) {
         Log("Cloud Handler - Sync", module: .cloudSync)
         guard let vaultID else {
             Log("Cloud Handler - VaultID not set!", module: .cloudSync, severity: .error)
             return
         }
-        syncHandler.synchronize(zoneID: .from(vaultID: vaultID))
+        syncHandler.synchronize(zoneID: .from(vaultID: vaultID), fromPush: fromPush)
     }
     
     private func clearCache() {

--- a/2PASS/Backup/Cloud/CloudHandler.swift
+++ b/2PASS/Backup/Cloud/CloudHandler.swift
@@ -344,10 +344,8 @@ final class CloudHandler: CloudHandlerType {
     
     private func syncNotAllowed() {
         Log("Cloud Handler - sync not allowed", module: .cloudSync)
-        setDisabled()
         clearCache()
-        currentState = .disabled
-        NotificationCenter.default.post(name: .presentSyncPremiumNeededScreen, object: nil)
+        currentState = .enabledNotAvailable(reason: .syncNotAllowed)
     }
     
     // MARK: -

--- a/2PASS/Backup/Cloud/CloudKit.swift
+++ b/2PASS/Backup/Cloud/CloudKit.swift
@@ -25,6 +25,7 @@ final class CloudKit {
     var userLoggedOut: Callback?
     var resetStack: Callback?
     
+    var fetchZoneChangesStarted: Callback?
     var fetchFinishedSuccessfuly: Callback?
     var changesSavedSuccessfuly: Callback?
     
@@ -44,7 +45,8 @@ final class CloudKit {
     private var deletedRecords: [DeletedItem] = []
     
     private var collectedActions: [CloudKitAction] = []
-    
+    private var retryWorkItem: DispatchWorkItem?
+
     private let syncTokenHandler = SyncTokenHandler()
     
     init() {
@@ -202,6 +204,8 @@ final class CloudKit {
     }
     
     private func fetchZoneChanges() {
+        fetchZoneChangesStarted?()
+
         guard zoneUpdated else {
             Log("CloudKit - NO zone changes - exiting", module: .cloudSync)
             DispatchQueue.main.async {
@@ -210,7 +214,7 @@ final class CloudKit {
             }
             return
         }
-        
+
         Log("CloudKit - clearing record changes", module: .cloudSync)
         clearRecordChanges()
         
@@ -335,6 +339,7 @@ final class CloudKit {
         syncTokenHandler.prepare()
         clearRecordChanges()
         collectedActions = []
+        cancelPendingRetry()
         operation?.cancel()
         operation = nil
     }
@@ -495,12 +500,23 @@ final class CloudKit {
         }
     }
     
+    var isWaitingForRetry: Bool { retryWorkItem != nil }
+
+    func cancelPendingRetry() {
+        retryWorkItem?.cancel()
+        retryWorkItem = nil
+    }
+
     private func retryAction(_ retryIn: TimeInterval = 2.0) {
         Log("CloudKit - Preparing to retry sync in \(retryIn)", module: .cloudSync)
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + retryIn) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.retryWorkItem = nil
             Log("CloudKit - Scheduled sync -> syncing", module: .cloudSync)
             self.cloudSync(zoneID: self.zoneID)
         }
+        retryWorkItem = workItem
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + retryIn, execute: workItem)
     }
 }
 

--- a/2PASS/Backup/Cloud/CloudKit.swift
+++ b/2PASS/Backup/Cloud/CloudKit.swift
@@ -44,6 +44,7 @@ final class CloudKit {
     private var deletedRecords: [DeletedItem] = []
     
     private var collectedActions: [CloudKitAction] = []
+    private var savedRecordsMetadata: [String: Data] = [:]
     
     private let syncTokenHandler = SyncTokenHandler()
     
@@ -56,6 +57,7 @@ final class CloudKit {
         Log("CloudKit - cloudSync()", module: .cloudSync)
         self.zoneID = zoneID
         collectedActions = []
+        savedRecordsMetadata = [:]
 
         DispatchQueue.global(qos: .utility).async {
             self.syncTokenHandler.prepare()
@@ -305,6 +307,7 @@ final class CloudKit {
                     module: .cloudSync,
                     save: false
                 )
+                self?.savedRecordsMetadata[recordID.recordName] = record.encodeSystemFields()
             case .failure(let error):
                 self?.savePartialOperationError(error)
                 Log(
@@ -335,10 +338,17 @@ final class CloudKit {
         syncTokenHandler.prepare()
         clearRecordChanges()
         collectedActions = []
+        savedRecordsMetadata = [:]
         operation?.cancel()
         operation = nil
     }
     
+    func consumeSavedRecordsMetadata() -> [String: Data] {
+        let metadata = savedRecordsMetadata
+        savedRecordsMetadata = [:]
+        return metadata
+    }
+
     // MARK: - ZONE
     
     private func zoneChanged(with zoneID: CKRecordZone.ID) {

--- a/2PASS/Backup/Cloud/CloudKit.swift
+++ b/2PASS/Backup/Cloud/CloudKit.swift
@@ -44,7 +44,6 @@ final class CloudKit {
     private var deletedRecords: [DeletedItem] = []
     
     private var collectedActions: [CloudKitAction] = []
-    private var savedRecordsMetadata: [String: Data] = [:]
     
     private let syncTokenHandler = SyncTokenHandler()
     
@@ -57,7 +56,6 @@ final class CloudKit {
         Log("CloudKit - cloudSync()", module: .cloudSync)
         self.zoneID = zoneID
         collectedActions = []
-        savedRecordsMetadata = [:]
 
         DispatchQueue.global(qos: .utility).async {
             self.syncTokenHandler.prepare()
@@ -307,7 +305,6 @@ final class CloudKit {
                     module: .cloudSync,
                     save: false
                 )
-                self?.savedRecordsMetadata[recordID.recordName] = record.encodeSystemFields()
             case .failure(let error):
                 self?.savePartialOperationError(error)
                 Log(
@@ -338,17 +335,10 @@ final class CloudKit {
         syncTokenHandler.prepare()
         clearRecordChanges()
         collectedActions = []
-        savedRecordsMetadata = [:]
         operation?.cancel()
         operation = nil
     }
     
-    func consumeSavedRecordsMetadata() -> [String: Data] {
-        let metadata = savedRecordsMetadata
-        savedRecordsMetadata = [:]
-        return metadata
-    }
-
     // MARK: - ZONE
     
     private func zoneChanged(with zoneID: CKRecordZone.ID) {

--- a/2PASS/Backup/Cloud/CloudKit.swift
+++ b/2PASS/Backup/Cloud/CloudKit.swift
@@ -46,6 +46,7 @@ final class CloudKit {
     
     private var collectedActions: [CloudKitAction] = []
     private var retryWorkItem: DispatchWorkItem?
+    private var retryCount: Int = 0
 
     private let syncTokenHandler = SyncTokenHandler()
     
@@ -208,6 +209,7 @@ final class CloudKit {
 
         guard zoneUpdated else {
             Log("CloudKit - NO zone changes - exiting", module: .cloudSync)
+            retryCount = 0
             DispatchQueue.main.async {
                 self.syncTokenHandler.commitChanges()
                 self.fetchFinishedSuccessfuly?()
@@ -387,7 +389,7 @@ final class CloudKit {
     
     private func savePartialOperationError(_ error: Error) {
         Log("CloudKit - partialOperationError: \(error)", module: .cloudSync)
-        if let action = errorParser.handle(error: error as NSError) {
+        if let action = errorParser.handle(error: error as NSError, retryCount: retryCount) {
             collectedActions.append(action)
         }
     }
@@ -398,7 +400,7 @@ final class CloudKit {
             next?()
             return
         }
-        if let error, let action = errorParser.handle(error: error as NSError) {
+        if let error, let action = errorParser.handle(error: error as NSError, retryCount: retryCount) {
             collectedActions.append(action)
         }
         guard let mostImportant = collectedActions.sortedByImportance.last else {
@@ -462,6 +464,7 @@ final class CloudKit {
     
     private func finishedFetchingZoneChange() {
         Log("CloudKit - finishedFetchingZoneChange", module: .cloudSync)
+        retryCount = 0
         zoneUpdated = false
         
         DispatchQueue.main.async {
@@ -484,6 +487,7 @@ final class CloudKit {
     
     private func changesSaved() {
         Log("CloudKit - Changes were saved successfully", module: .cloudSync)
+        retryCount = 0
         DispatchQueue.main.async {
             self.changesSavedSuccessfuly?()
         }
@@ -505,10 +509,12 @@ final class CloudKit {
     func cancelPendingRetry() {
         retryWorkItem?.cancel()
         retryWorkItem = nil
+        retryCount = 0
     }
 
     private func retryAction(_ retryIn: TimeInterval = 2.0) {
-        Log("CloudKit - Preparing to retry sync in \(retryIn)", module: .cloudSync)
+        retryCount += 1
+        Log("CloudKit - Preparing to retry sync in \(retryIn) (retry #\(retryCount))", module: .cloudSync)
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.retryWorkItem = nil

--- a/2PASS/Backup/Cloud/CloudKitErrorParser.swift
+++ b/2PASS/Backup/Cloud/CloudKitErrorParser.swift
@@ -36,18 +36,21 @@ extension Collection where Element == CloudKitAction {
 
 // swiftlint:disable legacy_objc_type
 final class CloudKitErrorParser {
-    private let minSecondsToRetry: TimeInterval = 2
-    private let maxSecondsToRetry: TimeInterval = 1800
-    private let midSecondsToRetry: TimeInterval = 600
-    
-    func handle(error: NSError) -> CloudKitAction? {
+    private let retryIntervals: [TimeInterval] = [2, 5, 10, 30, 60]
+    private let offlineRetryInterval: TimeInterval = 600
+
+    private func retryInterval(for retryCount: Int) -> TimeInterval {
+        retryIntervals[min(retryCount, retryIntervals.count - 1)]
+    }
+
+    func handle(error: NSError, retryCount: Int) -> CloudKitAction? {
         let userInfo = error.userInfo
         
         Log("Handling error \(error)", module: .cloudSync)
         
         if error.isOffline {
-            Log("iCloud is offline, retrying in \(midSecondsToRetry)s", module: .cloudSync)
-            return .retry(after: midSecondsToRetry)
+            Log("iCloud is offline, retrying in \(offlineRetryInterval)s", module: .cloudSync)
+            return .retry(after: offlineRetryInterval)
         }
         
         if let retry = userInfo[CKErrorRetryAfterKey] as? NSNumber {
@@ -57,36 +60,36 @@ final class CloudKitErrorParser {
         }
         
         guard let errorCode = CKError.Code(rawValue: error.code) else {
-            Log("Can't get error code from \(error). Purging and retrying", module: .cloudSync)
-            return .resetAndRetry(after: minSecondsToRetry)
+            let interval = retryInterval(for: retryCount)
+            Log("Can't get error code from \(error). Purging and retrying in \(interval)s", module: .cloudSync)
+            return .resetAndRetry(after: interval)
         }
         
         Log("Error code: \(errorCode)", module: .cloudSync)
         
         switch errorCode {
         case .internalError, .zoneNotFound, .serverResponseLost:
-            return .resetAndRetry(after: minSecondsToRetry)
-            
+            return .resetAndRetry(after: retryInterval(for: retryCount))
+
         case .networkUnavailable,
             .networkFailure,
             .serviceUnavailable,
             .requestRateLimited,
             .limitExceeded,
             .zoneBusy:
-            let seconds = TimeInterval.random(in: minSecondsToRetry...maxSecondsToRetry)
-            return .resetAndRetry(after: seconds)
-            
+            return .resetAndRetry(after: retryInterval(for: retryCount))
+
         case .operationCancelled:
             Log("Operation cancelled!", module: .cloudSync)
             return nil
-            
+
         case .changeTokenExpired,
                 .serverRecordChanged,
                 .unknownItem,
                 .constraintViolation,
                 .invalidArguments,
                 .batchRequestFailed:
-            return .resetAndRetry(after: minSecondsToRetry)
+            return .resetAndRetry(after: retryInterval(for: retryCount))
             
         case .missingEntitlement,
             .serverRejectedRequest,

--- a/2PASS/Backup/Cloud/CloudSync.swift
+++ b/2PASS/Backup/Cloud/CloudSync.swift
@@ -63,8 +63,8 @@ public final class CloudSync {
         checkForMigration(cloudCacheStorage: cloudCacheStorage)
     }
     
-    public func setMultiDeviceSyncEnabled(_ enabled: Bool) {
-        mergeHandler?.setMultiDeviceSyncEnabled(enabled)
+    public func setMultiDeviceSyncEnabled(_ enabled: Bool, takingOver: Bool = false) {
+        mergeHandler?.setMultiDeviceSyncEnabled(enabled, takingOver: takingOver)
     }
     
     public func setVaultID(_ vaultID: VaultID) {

--- a/2PASS/Backup/Cloud/CloudSync.swift
+++ b/2PASS/Backup/Cloud/CloudSync.swift
@@ -71,8 +71,8 @@ public final class CloudSync {
         cloudHandler?.setVaultID(vaultID: vaultID)
     }
     
-    public func synchronize() {
-        cloudHandler?.synchronize()
+    public func synchronize(fromPush: Bool = false) {
+        cloudHandler?.synchronize(fromPush: fromPush)
     }
 
     public func checkState() {

--- a/2PASS/Backup/Cloud/CloudTypes.swift
+++ b/2PASS/Backup/Cloud/CloudTypes.swift
@@ -19,6 +19,7 @@ public enum CloudCurrentState: Equatable {
         case restricted
         case schemaNotSupported(Int)
         case incorrectEncryption
+        case syncNotAllowed
     }
         
     public enum Sync: Equatable {

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -279,9 +279,9 @@ extension MergeHandler {
         mergeDeletedItems(local: localDeletedItems, cloud: cloudDeletedItems, vaultID: localVault.vaultID)
         mergeTags(local: localTags, cloud: cloudTags, vaultID: localVault.vaultID)
         mergeItems(local: localItems, cloud: cloudItems, vaultID: localVault.vaultID)
-        
-        handleItemsWhichAreDeleted()
-        handleTagsWhichAreDeleted()
+
+        handleItemsWhichAreDeleted(allLocalDeletedItems: localDeletedItems, allLocalItems: localItems)
+        handleTagsWhichAreDeleted(allLocalDeletedItems: localDeletedItems, allLocalTags: localTags)
         
         guard prepareChangesInDeletedItems(
             local: localDeletedItems,
@@ -400,30 +400,80 @@ private extension MergeHandler {
         }
     }
     
-    func handleItemsWhichAreDeleted() {
+    func handleItemsWhichAreDeleted(allLocalDeletedItems: [DeletedItemData], allLocalItems: [ItemEncryptedData]) {
+        var handledItemIDs: Set<ItemID> = []
+
         for deletedItems in deleted where deletedItems.value.isDeletedItem {
             let itemID = deletedItems.key
             if let item = items[itemID] {
-                // item was removed to trash
-                if deletedItems.value.deletedAt.isAfter(item.modificationDate) {
+                handledItemIDs.insert(itemID)
+                // item was removed to trash (equal dates = deletion wins)
+                if !deletedItems.value.deletedAt.isBefore(item.modificationDate) {
                     itemsForRemoval.append(item)
                     items[itemID] = nil
-                } else { // item was restored from trash
+                } else { // item was restored from trash (modified after deletion)
                     deletedForRemoval.append(deletedItems.value)
                     deleted[itemID] = nil
                 }
             }
         }
+
+        // Handle cloud deleted records where the item exists locally but wasn't in the
+        // items diff dict (because local and cloud items matched in mergeItems and were
+        // removed). Without this, the receiving device never moves items to trash.
+        for (itemID, deletedEntry) in deleted where deletedEntry.isDeletedItem {
+            guard !handledItemIDs.contains(itemID) else { continue }
+            if case .cloud = deletedEntry,
+               let localItem = allLocalItems.first(where: { $0.itemID == itemID }),
+               !deletedEntry.deletedAt.isBefore(localItem.modificationDate) {
+                itemIDsForDeletition.append(itemID)
+            }
+        }
+
+        // Handle cloud items that have matching local deleted records which were already
+        // resolved in mergeDeletedItems (local == cloud). Without this check, items
+        // re-uploaded by another device during a batch deletion race condition would
+        // bypass the deletion check and get restored from trash.
+        for localDeleted in allLocalDeletedItems where localDeleted.kind == .login {
+            let itemID = localDeleted.itemID
+            guard deleted[itemID] == nil else { continue }
+            if let item = items[itemID], !localDeleted.deletedAt.isBefore(item.modificationDate) {
+                items[itemID] = nil
+            }
+        }
     }
     
-    func handleTagsWhichAreDeleted() {
+    func handleTagsWhichAreDeleted(allLocalDeletedItems: [DeletedItemData], allLocalTags: [ItemTagEncryptedData]) {
+        var handledTagIDs: Set<ItemTagID> = []
+
         for deletedItems in deleted where deletedItems.value.isDeletedTag {
             let itemID = deletedItems.key
             if let tag = tags[itemID] {
-                if deletedItems.value.deletedAt.isAfter(tag.modificationDate) {
+                handledTagIDs.insert(itemID)
+                if !deletedItems.value.deletedAt.isBefore(tag.modificationDate) {
                     tagForRemoval.append(tag)
                     tags[itemID] = nil
                 }
+            }
+        }
+
+        // Handle cloud deleted records where the tag exists locally but wasn't in the
+        // tags diff dict (because local and cloud tags matched in mergeTags)
+        for (tagID, deletedEntry) in deleted where deletedEntry.isDeletedTag {
+            guard !handledTagIDs.contains(tagID) else { continue }
+            if case .cloud = deletedEntry,
+               let localTag = allLocalTags.first(where: { $0.tagID == tagID }),
+               !deletedEntry.deletedAt.isBefore(localTag.modificationDate) {
+                tagIDsForDeletition.append(tagID)
+            }
+        }
+
+        // Same race condition protection for tags
+        for localDeleted in allLocalDeletedItems where localDeleted.kind == .tag {
+            let itemID = localDeleted.itemID
+            guard deleted[itemID] == nil else { continue }
+            if let tag = tags[itemID], !localDeleted.deletedAt.isBefore(tag.modificationDate) {
+                tags[itemID] = nil
             }
         }
     }
@@ -599,6 +649,12 @@ private extension MergeHandler {
             switch del {
             case .local(let deletedItem):
                 deletedIDsForDeletition.append(deletedItem.itemID)
+                cloudStorageDeletedIDsForDeletition.append(deletedItem.itemID)
+                recordIDsForRemoval
+                    .append(
+                        CKRecord
+                            .ID(recordName: DeletedItemRecord.createRecordName(for: deletedItem.itemID), zoneID: zoneID)
+                    )
             case .cloud(let deletedItem, _):
                 cloudStorageDeletedIDsForDeletition.append(deletedItem.itemID)
                 recordIDsForRemoval
@@ -615,6 +671,8 @@ private extension MergeHandler {
             switch item {
             case .local(let itemData):
                 itemIDsForDeletition.append(itemData.itemID)
+                cloudStorageItemIDsForDeletition.append(itemData.itemID)
+                recordIDsForRemoval.append(CKRecord.ID(recordName: ItemRecord.createRecordName(for: itemData.itemID), zoneID: zoneID))
             case .cloud(let item, _):
                 cloudStorageItemIDsForDeletition.append(item.itemID)
                 recordIDsForRemoval.append(CKRecord.ID(recordName: ItemRecord.createRecordName(for: item.itemID), zoneID: zoneID))
@@ -627,6 +685,8 @@ private extension MergeHandler {
             switch tag {
             case .local(let tagData):
                 tagIDsForDeletition.append(tagData.tagID)
+                cloudStorageTagIDsForDeletition.append(tagData.tagID)
+                recordIDsForRemoval.append(CKRecord.ID(recordName: TagRecord.createRecordName(for: tagData.tagID), zoneID: zoneID))
             case .cloud(let tag, _):
                 cloudStorageTagIDsForDeletition.append(tag.tagID)
                 recordIDsForRemoval.append(CKRecord.ID(recordName: TagRecord.createRecordName(for: tag.tagID), zoneID: zoneID))

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -173,10 +173,13 @@ extension MergeHandler {
     func clear() {
         deleted = [:]
         items = [:]
+        tags = [:]
         deletedForRemoval = []
         itemsForRemoval = []
+        tagForRemoval = []
         recordsToCreateUpdate = []
         recordIDsForRemoval = []
+        recordItemIDsForDeletition = []
         deletedItemAdd = []
         deletedItemUpdate = []
         itemsAdd = []

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -103,7 +103,7 @@ extension MergeHandler {
         (createUpdate: recordsToCreateUpdate, delete: recordIDsForRemoval)
     }
     
-    func applyChanges() -> Bool {
+    func applyChanges(savedMetadata: [String: Data] = [:]) -> Bool {
         // local
         localStorage.createDeletedItems(deletedItemAdd)
         localStorage.updateDeletedItems(deletedItemUpdate)
@@ -143,20 +143,40 @@ extension MergeHandler {
         
         cloudStorageDeletedItemAdd
             .forEach {
+                let recordName = DeletedItemRecord.createRecordName(for: $0.deletedItem.itemID)
+                let metadata = savedMetadata[recordName] ?? $0.metadata
                 cloudCacheStorage
-                    .createDeletedItem(.init(deletedItem: $0.deletedItem, metadata: $0.metadata))
+                    .createDeletedItem(.init(deletedItem: $0.deletedItem, metadata: metadata))
             }
         cloudStorageDeletedItemUpdate
             .forEach {
+                let recordName = DeletedItemRecord.createRecordName(for: $0.deletedItem.itemID)
+                let metadata = savedMetadata[recordName] ?? $0.metadata
                 cloudCacheStorage
-                    .updateDeletedItem(.init(deletedItem: $0.deletedItem, metadata: $0.metadata))
+                    .updateDeletedItem(.init(deletedItem: $0.deletedItem, metadata: metadata))
             }
         
-        cloudStorageItemAdd.forEach { cloudCacheStorage.createItem(item: $0.item, metadata: $0.metadata) }
-        cloudStorageItemUpdate.forEach { cloudCacheStorage.updateItem(item: $0.item, metadata: $0.metadata) }
+        cloudStorageItemAdd.forEach {
+            let recordName = ItemRecord.createRecordName(for: $0.item.itemID)
+            let metadata = savedMetadata[recordName] ?? $0.metadata
+            cloudCacheStorage.createItem(item: $0.item, metadata: metadata)
+        }
+        cloudStorageItemUpdate.forEach {
+            let recordName = ItemRecord.createRecordName(for: $0.item.itemID)
+            let metadata = savedMetadata[recordName] ?? $0.metadata
+            cloudCacheStorage.updateItem(item: $0.item, metadata: metadata)
+        }
         
-        cloudStorageTagAdd.forEach { cloudCacheStorage.createTagItem(.init(tagItem: $0.tag, metadata: $0.metadata)) }
-        cloudStorageTagUpdate.forEach { cloudCacheStorage.updateTagItem(.init(tagItem: $0.tag, metadata: $0.metadata)) }
+        cloudStorageTagAdd.forEach {
+            let recordName = TagRecord.createRecordName(for: $0.tag.tagID)
+            let metadata = savedMetadata[recordName] ?? $0.metadata
+            cloudCacheStorage.createTagItem(.init(tagItem: $0.tag, metadata: metadata))
+        }
+        cloudStorageTagUpdate.forEach {
+            let recordName = TagRecord.createRecordName(for: $0.tag.tagID)
+            let metadata = savedMetadata[recordName] ?? $0.metadata
+            cloudCacheStorage.updateTagItem(.init(tagItem: $0.tag, metadata: metadata))
+        }
         
         cloudStorageDeletedIDsForDeletition.forEach(cloudCacheStorage.deleteDeletedItem)
         cloudStorageItemIDsForDeletition.forEach(cloudCacheStorage.deleteItem)

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -30,6 +30,7 @@ final class MergeHandler {
     private let jsonEncoder: JSONEncoder
     
     private var isMultiDeviceSyncEnabled: Bool = false
+    private var isTakingOverVault: Bool = false
     
     private var deleted: [DeletedItemID: Deleted] = [:]
     private var items: [ItemID: Item] = [:]
@@ -87,8 +88,9 @@ final class MergeHandler {
 }
 
 extension MergeHandler {
-    func setMultiDeviceSyncEnabled(_ enabled: Bool) {
+    func setMultiDeviceSyncEnabled(_ enabled: Bool, takingOver: Bool = false) {
         isMultiDeviceSyncEnabled = enabled
+        isTakingOverVault = takingOver
     }
     
     func setItemIDsForDeletition(_ itemIDsForDeletition: [CKRecord.ID]) {
@@ -250,10 +252,10 @@ extension MergeHandler {
             
             if ConstStorage.passwordWasChanged || cloudVault.deviceID != deviceID {
                 if cloudVault.deviceID != deviceID {
-                    if isMultiDeviceSyncEnabled {
+                    if isMultiDeviceSyncEnabled || isTakingOverVault {
                         cloudVault.update(deviceID: deviceID, updatedAt: date)
                         vaultAddIfDataModifed = cloudVault
-                        skipIfDataUnmodified = ConstStorage.passwordWasChanged == false
+                        skipIfDataUnmodified = !isTakingOverVault && ConstStorage.passwordWasChanged == false
                     } else {
                         syncNotAllowed?()
                         completion(.failure(.syncNotAllowed))

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -105,8 +105,8 @@ extension MergeHandler {
     
     func applyChanges() -> Bool {
         // local
-        deletedItemAdd.forEach(localStorage.createDeletedItem)
-        deletedItemUpdate.forEach(localStorage.updateDeletedItem)
+        localStorage.createDeletedItems(deletedItemAdd)
+        localStorage.updateDeletedItems(deletedItemUpdate)
         
         var moveFromTrash: [ItemID] = []
         let trashedItems = localStorage.listTrashedItemsIDs()

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -332,7 +332,13 @@ private extension MergeHandler {
         vaultID: VaultID
     ) {
         deleted = localDeletedItems.reduce(into: [DeletedItemID: Deleted]()) { result, deletedItem in
-            result[deletedItem.itemID] = Deleted.local(deletedItem)
+            if let existing = result[deletedItem.itemID] {
+                if deletedItem.deletedAt > existing.deletedAt {
+                    result[deletedItem.itemID] = Deleted.local(deletedItem)
+                }
+            } else {
+                result[deletedItem.itemID] = Deleted.local(deletedItem)
+            }
         }
         
         cloudDeletedItems.filter({ $0.deletedItem.vaultID == vaultID }).forEach { cloud in

--- a/2PASS/Backup/Cloud/MergeHandler.swift
+++ b/2PASS/Backup/Cloud/MergeHandler.swift
@@ -103,7 +103,7 @@ extension MergeHandler {
         (createUpdate: recordsToCreateUpdate, delete: recordIDsForRemoval)
     }
     
-    func applyChanges(savedMetadata: [String: Data] = [:]) -> Bool {
+    func applyChanges() -> Bool {
         // local
         localStorage.createDeletedItems(deletedItemAdd)
         localStorage.updateDeletedItems(deletedItemUpdate)
@@ -143,40 +143,20 @@ extension MergeHandler {
         
         cloudStorageDeletedItemAdd
             .forEach {
-                let recordName = DeletedItemRecord.createRecordName(for: $0.deletedItem.itemID)
-                let metadata = savedMetadata[recordName] ?? $0.metadata
                 cloudCacheStorage
-                    .createDeletedItem(.init(deletedItem: $0.deletedItem, metadata: metadata))
+                    .createDeletedItem(.init(deletedItem: $0.deletedItem, metadata: $0.metadata))
             }
         cloudStorageDeletedItemUpdate
             .forEach {
-                let recordName = DeletedItemRecord.createRecordName(for: $0.deletedItem.itemID)
-                let metadata = savedMetadata[recordName] ?? $0.metadata
                 cloudCacheStorage
-                    .updateDeletedItem(.init(deletedItem: $0.deletedItem, metadata: metadata))
+                    .updateDeletedItem(.init(deletedItem: $0.deletedItem, metadata: $0.metadata))
             }
         
-        cloudStorageItemAdd.forEach {
-            let recordName = ItemRecord.createRecordName(for: $0.item.itemID)
-            let metadata = savedMetadata[recordName] ?? $0.metadata
-            cloudCacheStorage.createItem(item: $0.item, metadata: metadata)
-        }
-        cloudStorageItemUpdate.forEach {
-            let recordName = ItemRecord.createRecordName(for: $0.item.itemID)
-            let metadata = savedMetadata[recordName] ?? $0.metadata
-            cloudCacheStorage.updateItem(item: $0.item, metadata: metadata)
-        }
+        cloudStorageItemAdd.forEach { cloudCacheStorage.createItem(item: $0.item, metadata: $0.metadata) }
+        cloudStorageItemUpdate.forEach { cloudCacheStorage.updateItem(item: $0.item, metadata: $0.metadata) }
         
-        cloudStorageTagAdd.forEach {
-            let recordName = TagRecord.createRecordName(for: $0.tag.tagID)
-            let metadata = savedMetadata[recordName] ?? $0.metadata
-            cloudCacheStorage.createTagItem(.init(tagItem: $0.tag, metadata: metadata))
-        }
-        cloudStorageTagUpdate.forEach {
-            let recordName = TagRecord.createRecordName(for: $0.tag.tagID)
-            let metadata = savedMetadata[recordName] ?? $0.metadata
-            cloudCacheStorage.updateTagItem(.init(tagItem: $0.tag, metadata: metadata))
-        }
+        cloudStorageTagAdd.forEach { cloudCacheStorage.createTagItem(.init(tagItem: $0.tag, metadata: $0.metadata)) }
+        cloudStorageTagUpdate.forEach { cloudCacheStorage.updateTagItem(.init(tagItem: $0.tag, metadata: $0.metadata)) }
         
         cloudStorageDeletedIDsForDeletition.forEach(cloudCacheStorage.deleteDeletedItem)
         cloudStorageItemIDsForDeletition.forEach(cloudCacheStorage.deleteItem)

--- a/2PASS/Backup/Cloud/ModificationBatchQueue.swift
+++ b/2PASS/Backup/Cloud/ModificationBatchQueue.swift
@@ -10,48 +10,57 @@ import Common
 
 final class ModificationBatchQueue {
     private let batchElementLimit = 400
-    
-    private var batchModify: [[CKRecord]] = []
-    private var batchDelete: [[CKRecord.ID]] = []
-    
-    private var batchCount: Int = 0
-    
+
+    private var batches: [(modify: [CKRecord], delete: [CKRecord.ID])] = []
+
     var finished: Bool {
-        batchCount < 0
+        batches.isEmpty
     }
-    
+
     func setRecordsToModifyOnServer(_ modify: [CKRecord]?, deleteIDs: [CKRecord.ID]?) {
-        if let modify {
-            batchModify = modify.grouped(by: batchElementLimit)
+        let allModify = modify ?? []
+        let allDelete = deleteIDs ?? []
+
+        batches = []
+
+        var modifyIndex = allModify.startIndex
+        var deleteIndex = allDelete.startIndex
+
+        while modifyIndex < allModify.endIndex || deleteIndex < allDelete.endIndex {
+            let remaining = batchElementLimit
+
+            let modifyEnd = min(modifyIndex + remaining, allModify.endIndex)
+            let modifyBatch = Array(allModify[modifyIndex..<modifyEnd])
+            modifyIndex = modifyEnd
+
+            let deleteRemaining = remaining - modifyBatch.count
+            let deleteEnd = min(deleteIndex + deleteRemaining, allDelete.endIndex)
+            let deleteBatch = Array(allDelete[deleteIndex..<deleteEnd])
+            deleteIndex = deleteEnd
+
+            batches.append((modify: modifyBatch, delete: deleteBatch))
         }
-        
-        if let deleteIDs {
-            batchDelete = deleteIDs.grouped(by: batchElementLimit)
-        }
-        
-        let maxBatchCount = batchModify.count + batchDelete.count
-        batchCount = maxBatchCount - 1
-        
-        Log("ModificationBatchQueue - spliting into \(maxBatchCount) batches", module: .cloudSync)
+
+        Log("ModificationBatchQueue - spliting into \(batches.count) batches", module: .cloudSync)
     }
-    
+
     func currentBatch() -> (modify: [CKRecord]?, delete: [CKRecord.ID]?) {
-        if let delete = batchDelete.popLast() {
-            return (modify: nil, delete: delete)
+        guard let batch = batches.first else {
+            return (modify: nil, delete: nil)
         }
-        if let modify = batchModify.popLast() {
-            return (modify: modify, delete: nil)
-        }
-        return (modify: nil, delete: nil)
+        return (
+            modify: batch.modify.isEmpty ? nil : batch.modify,
+            delete: batch.delete.isEmpty ? nil : batch.delete
+        )
     }
-    
+
     func prevBatchProcessed() {
-        batchCount -= 1
+        if !batches.isEmpty {
+            batches.removeFirst()
+        }
     }
-    
+
     func clear() {
-        batchCount = 0
-        batchModify = []
-        batchDelete = []
+        batches = []
     }
 }

--- a/2PASS/Backup/Cloud/Protocols/LocalStorage.swift
+++ b/2PASS/Backup/Cloud/Protocols/LocalStorage.swift
@@ -14,7 +14,9 @@ public protocol LocalStorage: AnyObject {
     func moveFromTrash(_ itemID: ItemID)
     func listTrashedItemsIDs() -> [ItemID]
     func createDeletedItem(_ deletedItem: DeletedItemData)
+    func createDeletedItems(_ items: [DeletedItemData])
     func updateDeletedItem(_ deletedItem: DeletedItemData)
+    func updateDeletedItems(_ items: [DeletedItemData])
     func createItem(_ item: ItemEncryptedData)
     func updateItem(_ item: ItemEncryptedData)
     func createTag(_ tag: ItemTagData)

--- a/2PASS/Backup/Cloud/SyncHandler.swift
+++ b/2PASS/Backup/Cloud/SyncHandler.swift
@@ -198,8 +198,7 @@ final class SyncHandler {
         isSyncing = false
         
         Log("SyncHandler - Sending current cloud state to local database", module: .cloudSync)
-        let savedMetadata = cloudKit.consumeSavedRecordsMetadata()
-        let shouldRefreshLocalData = mergeHandler.applyChanges(savedMetadata: savedMetadata)
+        let shouldRefreshLocalData = mergeHandler.applyChanges()
         
         finishedSync?()
         if shouldRefreshLocalData {

--- a/2PASS/Backup/Cloud/SyncHandler.swift
+++ b/2PASS/Backup/Cloud/SyncHandler.swift
@@ -18,7 +18,10 @@ final class SyncHandler {
     
     private var isSyncing = false
     private var applyingChanges = false
+    private var fetchStarted = false
+    private var needsResync = false
     private var currentDate = Date()
+    private var lastZoneID: CKRecordZone.ID?
         
     typealias OtherError = (NSError) -> Void
     
@@ -45,6 +48,7 @@ final class SyncHandler {
                 
         cloudKit.deletedEntries = { [weak self] entries in self?.deleteEntries(entries) }
         cloudKit.updatedEntries = { [weak self] entries in self?.updateEntries(entries) }
+        cloudKit.fetchZoneChangesStarted = { [weak self] in self?.fetchStarted = true }
         cloudKit.fetchFinishedSuccessfuly = { [weak self] in self?.fetchFinishedSuccessfuly() }
         cloudKit.changesSavedSuccessfuly = { [weak self] in self?.changesSavedSuccessfuly() }
         
@@ -83,15 +87,27 @@ final class SyncHandler {
         ConstStorage.clearZone()
     }
     
-    func synchronize(zoneID: CKRecordZone.ID) {
-        guard !isSyncing else {
-            Log("SyncHandler - Can't start sync. Already in progress. Exiting", module: .cloudSync)
-            return
+    func synchronize(zoneID: CKRecordZone.ID, fromPush: Bool = false) {
+        if isSyncing {
+            if cloudKit.isWaitingForRetry {
+                Log("SyncHandler - Cancelling pending retry, starting fresh sync", module: .cloudSync)
+                cloudKit.cancelPendingRetry()
+            } else if fromPush, fetchStarted {
+                Log("SyncHandler - Sync in progress. Marking needsResync (push received)", module: .cloudSync)
+                needsResync = true
+                return
+            } else {
+                Log("SyncHandler - Sync in progress. Skipping", module: .cloudSync)
+                return
+            }
         }
         Log("SyncHandler - Sync Handler: synchronizing", module: .cloudSync)
         isSyncing = true
+        fetchStarted = false
+        needsResync = false
+        lastZoneID = zoneID
         startedSync?()
-        
+
         mergeHandler.clear()
         modifyQueue.clear()
         cloudKit.cloudSync(zoneID: zoneID)
@@ -100,6 +116,7 @@ final class SyncHandler {
     func clearCacheAndDisable() {
         Log("SyncHandler - Sync Handler: clearCacheAndDisable", module: .cloudSync)
         isSyncing = false
+        needsResync = false
         resetStack()
         cloudKit.clear()
     }
@@ -196,19 +213,27 @@ final class SyncHandler {
         guard isSyncing else { return }
         Log("SyncHandler - Sync completed, clearing changes for sending", module: .cloudSync)
         isSyncing = false
-        
+
         Log("SyncHandler - Sending current cloud state to local database", module: .cloudSync)
         let shouldRefreshLocalData = mergeHandler.applyChanges()
-        
+
         finishedSync?()
         if shouldRefreshLocalData {
             refreshLocalData?()
+        }
+
+        if needsResync, let zoneID = lastZoneID {
+            Log("SyncHandler - Re-syncing due to push received during previous sync", module: .cloudSync)
+            needsResync = false
+            synchronize(zoneID: zoneID)
         }
     }
     
     private func resetStack() {
         Log("SyncHandler - Sync Handler: resetStack", module: .cloudSync)
         applyingChanges = false
+        fetchStarted = false
+        needsResync = false
         modifyQueue.clear()
         mergeHandler.clear()
         cacheHandler.purge()

--- a/2PASS/Backup/Cloud/SyncHandler.swift
+++ b/2PASS/Backup/Cloud/SyncHandler.swift
@@ -198,7 +198,8 @@ final class SyncHandler {
         isSyncing = false
         
         Log("SyncHandler - Sending current cloud state to local database", module: .cloudSync)
-        let shouldRefreshLocalData = mergeHandler.applyChanges()
+        let savedMetadata = cloudKit.consumeSavedRecordsMetadata()
+        let shouldRefreshLocalData = mergeHandler.applyChanges(savedMetadata: savedMetadata)
         
         finishedSync?()
         if shouldRefreshLocalData {

--- a/2PASS/Backup/Cloud/SyncHandler.swift
+++ b/2PASS/Backup/Cloud/SyncHandler.swift
@@ -161,7 +161,10 @@ final class SyncHandler {
                 case .schemaNotSupported: break
                 case .missingEncryption: self?.isSyncing = false
                 case .incorrectEncryption: self?.otherError?(error as NSError)
-                case .noLocalVault, .mergeError, .syncNotAllowed: self?.resetStack()
+                case .noLocalVault, .mergeError:
+                    self?.isSyncing = false
+                    self?.resetStack()
+                case .syncNotAllowed: self?.resetStack()
                 }
             }
         }

--- a/2PASS/Common/DataTypes/ItemData.swift
+++ b/2PASS/Common/DataTypes/ItemData.swift
@@ -276,6 +276,24 @@ extension _ItemData {
             content: content
         )
     }
+
+    public func update(trashedStatus: ItemTrashedStatus) -> Self {
+        _ItemData(
+            id: id,
+            vaultId: vaultId,
+            metadata: ItemMetadata(
+                creationDate: metadata.creationDate,
+                modificationDate: metadata.modificationDate,
+                protectionLevel: metadata.protectionLevel,
+                trashedStatus: trashedStatus,
+                tagIds: metadata.tagIds
+            ),
+            name: name,
+            contentType: contentType,
+            contentVersion: contentVersion,
+            content: content
+        )
+    }
 }
 
 extension ItemData {
@@ -307,6 +325,21 @@ extension ItemData {
             return .wifi(data.update(modificationDate: modificationDate, tagIds: tagIds))
         case .raw(let data):
             return .raw(data.update(modificationDate: modificationDate, tagIds: tagIds))
+        }
+    }
+
+    public func update(trashedStatus: ItemTrashedStatus) -> Self {
+        switch self {
+        case .login(let data):
+            return .login(data.update(trashedStatus: trashedStatus))
+        case .secureNote(let data):
+            return .secureNote(data.update(trashedStatus: trashedStatus))
+        case .paymentCard(let data):
+            return .paymentCard(data.update(trashedStatus: trashedStatus))
+        case .wifi(let data):
+            return .wifi(data.update(trashedStatus: trashedStatus))
+        case .raw(let data):
+            return .raw(data.update(trashedStatus: trashedStatus))
         }
     }
 }

--- a/2PASS/CommonUI/Passwords/Interactor/PasswordsModuleInteractor.swift
+++ b/2PASS/CommonUI/Passwords/Interactor/PasswordsModuleInteractor.swift
@@ -27,6 +27,7 @@ protocol PasswordsModuleInteracting: AnyObject {
     func setSearchPhrase(_ searchPhrase: String?)
 
     func moveToTrash(_ itemID: ItemID)
+    func moveToTrash(_ itemIDs: [ItemID])
     func copyUsername(_ itemID: ItemID) -> Bool
     func copyPassword(_ itemID: ItemID) -> Bool
     func copySecureNote(_ itemID: ItemID) -> Bool
@@ -218,7 +219,20 @@ extension PasswordsModuleInteractor: PasswordsModuleInteracting {
             }
         }
     }
-    
+
+    func moveToTrash(_ itemIDs: [ItemID]) {
+        Log("PasswordsModuleInteractor: Batch move to trash: \(itemIDs.count) items", module: .moduleInteractor)
+        let trashedItems = itemsInteractor.markAsTrashed(for: itemIDs)
+        let loginItems = trashedItems.compactMap(\.asLoginItem)
+        itemsInteractor.saveStorage()
+        syncChangeTriggerInteractor.trigger()
+        if !loginItems.isEmpty {
+            Task.detached(priority: .utility) { [autoFillCredentialsInteractor] in
+                try await autoFillCredentialsInteractor.removeSuggestions(for: loginItems)
+            }
+        }
+    }
+
     func copyUsername(_ itemID: ItemID) -> Bool {
         guard let loginItem = itemsInteractor.getItem(for: itemID, checkInTrash: false)?.asLoginItem,
               let username = loginItem.username

--- a/2PASS/CommonUI/Passwords/Presenter/PasswordsPresenter.swift
+++ b/2PASS/CommonUI/Passwords/Presenter/PasswordsPresenter.swift
@@ -262,7 +262,7 @@ extension PasswordsPresenter {
 
         Task { @MainActor in
             if await flowController.toConfirmMultiselectDelete(selectedCount: itemIDs.count, source: source) {
-                itemIDs.forEach { interactor.moveToTrash($0) }
+                interactor.moveToTrash(itemIDs)
                 view?.exitEditingMode()
                 reload()
             }

--- a/2PASS/CommonUI/Passwords/Presenter/PasswordsPresenter.swift
+++ b/2PASS/CommonUI/Passwords/Presenter/PasswordsPresenter.swift
@@ -93,7 +93,7 @@ final class PasswordsPresenter {
         self.iconsDataSource = RemoteImageCollectionDataSource(fetcher: IconFetcherProxy(interactor: interactor))
 
         notificationCenter.addObserver(self, selector: #selector(syncFinished), name: .webDAVStateChange, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(iCloudSyncFinished), name: .cloudStateChanged, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(iCloudSyncFinished), name: .cloudRefreshLocalData, object: nil)
         notificationCenter.addObserver(self, selector: #selector(userLoggedIn), name: .userLoggedIn, object: nil)
         notificationCenter.addObserver(self, selector: #selector(didImportItems), name: .didImportItems, object: nil)
         

--- a/2PASS/Data/Adapters/LocalStorageImpl.swift
+++ b/2PASS/Data/Adapters/LocalStorageImpl.swift
@@ -55,7 +55,11 @@ extension LocalStorageImpl: LocalStorage {
             deletedAt: deletedItem.deletedAt
         )
     }
-    
+
+    func createDeletedItems(_ items: [DeletedItemData]) {
+        deletedItemsInteractor.createDeletedItems(items)
+    }
+
     func moveFromTrash(_ itemID: ItemID) {
         itemsInteractor.markAsNotTrashed(for: itemID)
     }
@@ -66,6 +70,10 @@ extension LocalStorageImpl: LocalStorage {
             kind: deletedItem.kind,
             deletedAt: deletedItem.deletedAt
         )
+    }
+
+    func updateDeletedItems(_ items: [DeletedItemData]) {
+        deletedItemsInteractor.updateDeletedItems(items)
     }
     
     func createItem(_ item: ItemEncryptedData) {

--- a/2PASS/Data/Adapters/LocalStorageImpl.swift
+++ b/2PASS/Data/Adapters/LocalStorageImpl.swift
@@ -97,11 +97,11 @@ extension LocalStorageImpl: LocalStorage {
     }
     
     func removeTag(_ tagID: ItemTagID) {
-        tagInteractor.deleteTag(tagID: tagID)
+        tagInteractor.externalDeleteTag(tagID: tagID)
     }
     
     func removeItem(_ itemID: ItemID) {
-        itemsInteractor.markAsTrashed(for: itemID)
+        itemsInteractor.externalMarkAsTrashed(for: itemID)
     }
     
     func currentVault() -> VaultEncryptedData? {

--- a/2PASS/Data/Interactors/AutoFillCredentialsInteractor.swift
+++ b/2PASS/Data/Interactors/AutoFillCredentialsInteractor.swift
@@ -14,7 +14,8 @@ public protocol AutoFillCredentialsInteracting: AnyObject {
     func replaceSuggestions(from passwordData: LoginItemData, itemID: ItemID, username: String?, uris: [PasswordURI]?, protectionLevel: ItemProtectionLevel) async throws
     func replaceSuggestions(for items: [LoginItemData]) async throws
     func removeSuggestions(for passwordData: LoginItemData) async throws
-    
+    func removeSuggestions(for loginData: [LoginItemData]) async throws
+
     func syncSuggestions() async throws
 }
 
@@ -101,6 +102,27 @@ final class AutoFillCredentialsInteractor: AutoFillCredentialsInteracting {
         }
     }
     
+    func removeSuggestions(for loginData: [LoginItemData]) async throws {
+        let identities: [ASPasswordCredentialIdentity] = loginData.flatMap { item in
+            item.uris?.compactMap { uri -> ASPasswordCredentialIdentity? in
+                guard let uriNormalized = uriInteractor.normalize(uri.uri) else { return nil }
+                return ASPasswordCredentialIdentity(
+                    serviceIdentifier: .init(identifier: uriNormalized, type: .URL),
+                    user: item.username ?? "",
+                    recordIdentifier: item.id.uuidString
+                )
+            } ?? []
+        }
+        guard !identities.isEmpty else { return }
+        Log("Autofill - Start batch remove suggestions for \(loginData.count) items", module: .autofill)
+        do {
+            try await store.removeCredentialIdentities(identities as [any ASCredentialIdentity])
+            Log("Autofill - Batch remove suggestions completed", module: .autofill)
+        } catch {
+            Log("Autofill - Batch remove suggestions failure: \(error)", module: .autofill)
+        }
+    }
+
     func syncSuggestions() async throws { // TODO: Naive implementation. Should migrate to incremental updates.
         let isEnabled = await mainRepository.refreshAutoFillStatus()
         guard isEnabled else {

--- a/2PASS/Data/Interactors/CloudSyncInteractor.swift
+++ b/2PASS/Data/Interactors/CloudSyncInteractor.swift
@@ -12,10 +12,14 @@ public protocol CloudSyncInteracting: AnyObject {
     var currentState: CloudState { get }
     var lastSuccessSyncDate: Date? { get }
     func setup(takeoverVault: Bool)
-    func synchronize()
+    func synchronize(fromPush: Bool)
     func enable()
     func disable()
     func clearBackup()
+}
+
+public extension CloudSyncInteracting {
+    func synchronize() { synchronize(fromPush: false) }
 }
 
 final class CloudSyncInteractor {
@@ -91,8 +95,8 @@ extension CloudSyncInteractor: CloudSyncInteracting {
         }
     }
     
-    func synchronize() {
-        mainRepository.synchronizeBackup()
+    func synchronize(fromPush: Bool = false) {
+        mainRepository.synchronizeBackup(fromPush: fromPush)
     }
     
     func enable() {

--- a/2PASS/Data/Interactors/CloudSyncInteractor.swift
+++ b/2PASS/Data/Interactors/CloudSyncInteractor.swift
@@ -87,7 +87,7 @@ extension CloudSyncInteractor: CloudSyncInteracting {
             return
         }
         mainRepository.cloudSync.setVaultID(currentVaultID)
-        mainRepository.cloudSync.setMultiDeviceSyncEnabled(paymentStatusInteractor.entitlements.multiDeviceSync || takeoverVault)
+        mainRepository.cloudSync.setMultiDeviceSyncEnabled(paymentStatusInteractor.entitlements.multiDeviceSync, takingOver: takeoverVault)
         mainRepository.cloudSync.checkState()
         
         if !takeoverVault {

--- a/2PASS/Data/Interactors/DeletedItemsInteractor.swift
+++ b/2PASS/Data/Interactors/DeletedItemsInteractor.swift
@@ -9,8 +9,8 @@ import Common
 
 public protocol DeletedItemsInteracting: AnyObject {
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
+    func createDeletedItems(_ items: [DeletedItemData])
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
-    func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems() -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
 }
@@ -29,11 +29,38 @@ extension DeletedItemsInteractor: DeletedItemsInteracting {
             Log("DeletedItemsInteractor: Error while getting vaultID for Deleted Password creation", module: .interactor, severity: .error)
             return
         }
-        mainRepository.createDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
+        if let existing = mainRepository.deletedItem(id: id) {
+            if deletedAt > existing.deletedAt {
+                mainRepository.updateDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
+            }
+        } else {
+            mainRepository.createDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
+        }
     }
-    
-    func deletedItem(id: DeletedItemID) -> DeletedItemData? {
-        mainRepository.deletedItem(id: id)
+
+    func createDeletedItems(_ items: [DeletedItemData]) {
+        guard !items.isEmpty else { return }
+        guard let vaultID = mainRepository.selectedVault?.vaultID else {
+            Log("DeletedItemsInteractor: Error while getting vaultID for batch Deleted Password creation", module: .interactor, severity: .error)
+            return
+        }
+        let ids = Set(items.map(\.itemID))
+        let existingByID = mainRepository.listDeletedItems(ids: ids)
+            .reduce(into: [DeletedItemID: DeletedItemData]()) { $0[$1.itemID] = $1 }
+
+        for item in items {
+            if let existing = existingByID[item.itemID] {
+                if item.deletedAt > existing.deletedAt {
+                    mainRepository.updateDeletedItem(
+                        id: item.itemID, kind: item.kind, deletedAt: item.deletedAt, in: vaultID
+                    )
+                }
+            } else {
+                mainRepository.createDeletedItem(
+                    id: item.itemID, kind: item.kind, deletedAt: item.deletedAt, in: vaultID
+                )
+            }
+        }
     }
 
     func listDeletedItems() -> [DeletedItemData] {

--- a/2PASS/Data/Interactors/DeletedItemsInteractor.swift
+++ b/2PASS/Data/Interactors/DeletedItemsInteractor.swift
@@ -11,6 +11,7 @@ public protocol DeletedItemsInteracting: AnyObject {
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
     func createDeletedItems(_ items: [DeletedItemData])
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
+    func updateDeletedItems(_ items: [DeletedItemData])
     func listDeletedItems() -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
 }
@@ -81,5 +82,10 @@ extension DeletedItemsInteractor: DeletedItemsInteracting {
             return
         }
         mainRepository.updateDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
+    }
+
+    func updateDeletedItems(_ items: [DeletedItemData]) {
+        guard !items.isEmpty else { return }
+        mainRepository.updateDeletedItems(items)
     }
 }

--- a/2PASS/Data/Interactors/DeletedItemsInteractor.swift
+++ b/2PASS/Data/Interactors/DeletedItemsInteractor.swift
@@ -10,6 +10,7 @@ import Common
 public protocol DeletedItemsInteracting: AnyObject {
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date)
+    func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems() -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
 }
@@ -31,6 +32,10 @@ extension DeletedItemsInteractor: DeletedItemsInteracting {
         mainRepository.createDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
     }
     
+    func deletedItem(id: DeletedItemID) -> DeletedItemData? {
+        mainRepository.deletedItem(id: id)
+    }
+
     func listDeletedItems() -> [DeletedItemData] {
         guard let vaultID = mainRepository.selectedVault?.vaultID else {
             Log("DeletedItemsInteractor: Error while getting vaultID for listing Deleted Password", module: .interactor, severity: .error)

--- a/2PASS/Data/Interactors/ItemsImportInteractor.swift
+++ b/2PASS/Data/Interactors/ItemsImportInteractor.swift
@@ -44,12 +44,8 @@ extension ItemsImportInteractor: ItemsImportInteracting {
     }
     
     func importDeleted(_ deleted: [DeletedItemData]) {
-        let current = Set(deletedItemsInteractor.listDeletedItems())
-        let toAdd = Set(deleted).subtracting(current)
-        toAdd.forEach {
-            deletedItemsInteractor.createDeletedItem(id: $0.itemID, kind: $0.kind, deletedAt: $0.deletedAt)
-        }
-        Log("ItemsImportInteractor - deleted items to add: \(toAdd.count)", module: .interactor)
+        deletedItemsInteractor.createDeletedItems(deleted)
+        Log("ItemsImportInteractor - deleted items to import: \(deleted.count)", module: .interactor)
         itemsInteractor.saveStorage()
     }
 }

--- a/2PASS/Data/Interactors/ItemsInteractor.swift
+++ b/2PASS/Data/Interactors/ItemsInteractor.swift
@@ -61,6 +61,7 @@ public protocol ItemsInteracting: AnyObject {
     
     func deleteItem(for itemID: ItemID)
     func markAsTrashed(for itemID: ItemID)
+    @discardableResult func markAsTrashed(for itemIDs: [ItemID]) -> [ItemData]
     func externalMarkAsTrashed(for itemID: ItemID)
     func markAsNotTrashed(for itemID: ItemID)
     
@@ -428,7 +429,7 @@ extension ItemsInteractor: ItemsInteracting {
         }
         return item
     }
-    
+
     func getEncryptedItemEntity(itemID: ItemID) -> ItemEncryptedData? {
         mainRepository.getEncryptedItemEntity(itemID: itemID)
     }
@@ -522,6 +523,55 @@ extension ItemsInteractor: ItemsInteracting {
         deletedItemsInteractor.createDeletedItem(id: itemID, kind: .login, deletedAt: date)
     }
     
+    @discardableResult
+    func markAsTrashed(for itemIDs: [ItemID]) -> [ItemData] {
+        guard !itemIDs.isEmpty else { return [] }
+        guard let selectedVault = mainRepository.selectedVault else {
+            Log("ItemsInteractor: markAsTrashed batch. No vault", module: .interactor, severity: .error)
+            return []
+        }
+
+        let date = mainRepository.currentDate
+        let trashedStatus = ItemTrashedStatus.yes(trashingDate: date)
+
+        Log(
+            "ItemsInteractor: Batch marking as trashed for \(itemIDs.count) items",
+            module: .interactor
+        )
+
+        let items = mainRepository.listItems(options: .includeItems(itemIDs))
+        let updatedItems = items.map { $0.update(trashedStatus: trashedStatus) }
+        mainRepository.metadataItemsBatchUpdate(updatedItems)
+
+        let encryptedItems = mainRepository.listEncryptedItems(
+            in: selectedVault.vaultID,
+            itemIDs: itemIDs,
+            excludeProtectionLevels: nil
+        )
+        let updatedEncryptedItems = encryptedItems.map {
+            ItemEncryptedData(
+                itemID: $0.itemID,
+                creationDate: $0.creationDate,
+                modificationDate: date,
+                trashedStatus: trashedStatus,
+                protectionLevel: $0.protectionLevel,
+                contentType: $0.contentType,
+                contentVersion: $0.contentVersion,
+                content: $0.content,
+                vaultID: $0.vaultID,
+                tagIds: $0.tagIds
+            )
+        }
+        mainRepository.encryptedItemsBatchUpdate(updatedEncryptedItems)
+
+        let deletedItems = itemIDs.map {
+            DeletedItemData(itemID: $0, vaultID: selectedVault.vaultID, kind: .login, deletedAt: date)
+        }
+        deletedItemsInteractor.createDeletedItems(deletedItems)
+
+        return items
+    }
+
     func externalMarkAsTrashed(for itemID: ItemID) {
         Log(
             "ItemsInteractor: External marking as trashed for itemID: \(itemID)",

--- a/2PASS/Data/Interactors/MigrationInteractor.swift
+++ b/2PASS/Data/Interactors/MigrationInteractor.swift
@@ -69,9 +69,12 @@ final class MigrationInteractor: MigrationInteracting {
         
         if lastKnownAppVersion?.compare("1.7.0", options: .numeric) == .orderedAscending || lastKnownAppVersion == nil {
             mainRepository.migrateLegacyValuesToSharedDefaults()
-            mainRepository.removeDuplicatedDeletedItems()
         }
 
+        if lastKnownAppVersion?.compare("1.7.1", options: .numeric) == .orderedAscending {
+            mainRepository.removeDuplicatedDeletedItems()
+        }
+        
         mainRepository.saveEncryptedStorage()
 
         mainRepository.setLastKnownAppVersion(appVersion)

--- a/2PASS/Data/Interactors/MigrationInteractor.swift
+++ b/2PASS/Data/Interactors/MigrationInteractor.swift
@@ -69,6 +69,7 @@ final class MigrationInteractor: MigrationInteracting {
         
         if lastKnownAppVersion?.compare("1.7.0", options: .numeric) == .orderedAscending || lastKnownAppVersion == nil {
             mainRepository.migrateLegacyValuesToSharedDefaults()
+            mainRepository.removeDuplicatedDeletedItems()
         }
 
         mainRepository.saveEncryptedStorage()

--- a/2PASS/Data/Interactors/MigrationInteractor.swift
+++ b/2PASS/Data/Interactors/MigrationInteractor.swift
@@ -71,7 +71,7 @@ final class MigrationInteractor: MigrationInteracting {
             mainRepository.migrateLegacyValuesToSharedDefaults()
         }
 
-        if lastKnownAppVersion?.compare("1.7.1", options: .numeric) == .orderedAscending {
+        if lastKnownAppVersion?.compare("1.8.0", options: .numeric) == .orderedAscending {
             mainRepository.removeDuplicatedDeletedItems()
         }
         

--- a/2PASS/Data/Interactors/SyncInteractor.swift
+++ b/2PASS/Data/Interactors/SyncInteractor.swift
@@ -79,9 +79,7 @@ extension SyncInteractor: SyncInteracting {
         
         deletedItemsInteractor.createDeletedItems(addedDeleted)
         
-        modifiedDeleted.forEach({
-            deletedItemsInteractor.updateDeletedItem(id: $0.itemID, kind: $0.kind, deletedAt: $0.deletedAt)
-        })
+        deletedItemsInteractor.updateDeletedItems(modifiedDeleted)
         
         removedDeleted.forEach { deleted in
             deletedItemsInteractor.deleteDeletedItem(id: deleted.itemID)

--- a/2PASS/Data/Interactors/SyncInteractor.swift
+++ b/2PASS/Data/Interactors/SyncInteractor.swift
@@ -77,9 +77,7 @@ extension SyncInteractor: SyncInteracting {
             tagInteractor.externalDeleteTag(tagID: $0.tagID)
         })
         
-        addedDeleted.forEach({
-            deletedItemsInteractor.createDeletedItem(id: $0.itemID, kind: $0.kind, deletedAt: $0.deletedAt)
-        })
+        deletedItemsInteractor.createDeletedItems(addedDeleted)
         
         modifiedDeleted.forEach({
             deletedItemsInteractor.updateDeletedItem(id: $0.itemID, kind: $0.kind, deletedAt: $0.deletedAt)

--- a/2PASS/Data/Interactors/TagInteractor.swift
+++ b/2PASS/Data/Interactors/TagInteractor.swift
@@ -233,13 +233,7 @@ extension TagInteractor: TagInteracting {
         mainRepository.deleteTag(tagID: tagID)
         mainRepository.deleteEncryptedTag(tagID: tagID)
 
-        if let existingDeletedItem = deletedItemsInteractor.deletedItem(id: tagID) {
-            if currentDate > existingDeletedItem.deletedAt {
-                deletedItemsInteractor.updateDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
-            }
-        } else {
-            deletedItemsInteractor.createDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
-        }
+        deletedItemsInteractor.createDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
     }
     
     func externalDeleteTag(tagID: ItemTagID) {

--- a/2PASS/Data/Interactors/TagInteractor.swift
+++ b/2PASS/Data/Interactors/TagInteractor.swift
@@ -232,8 +232,14 @@ extension TagInteractor: TagInteracting {
         
         mainRepository.deleteTag(tagID: tagID)
         mainRepository.deleteEncryptedTag(tagID: tagID)
-        
-        deletedItemsInteractor.createDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
+
+        if let existingDeletedItem = deletedItemsInteractor.deletedItem(id: tagID) {
+            if currentDate > existingDeletedItem.deletedAt {
+                deletedItemsInteractor.updateDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
+            }
+        } else {
+            deletedItemsInteractor.createDeletedItem(id: tagID, kind: .tag, deletedAt: currentDate)
+        }
     }
     
     func externalDeleteTag(tagID: ItemTagID) {

--- a/2PASS/Data/Interactors/TagInteractor.swift
+++ b/2PASS/Data/Interactors/TagInteractor.swift
@@ -104,8 +104,9 @@ extension TagInteractor: TagInteracting {
         var data = data
         if shouldMigrateColor(data.color) {
             data.color = suggestedNewColor()
+            data.modificationDate = mainRepository.currentDate
         }
-        
+
         mainRepository.createTag(
             ItemTagData(
                 tagID: data.id,
@@ -163,6 +164,7 @@ extension TagInteractor: TagInteracting {
                     data.color = oldTag.color
                 }
             }
+            data.modificationDate = mainRepository.currentDate
         }
         
         mainRepository.updateTag(

--- a/2PASS/Data/Interactors/UpdateAppPromptInteractor.swift
+++ b/2PASS/Data/Interactors/UpdateAppPromptInteractor.swift
@@ -137,7 +137,7 @@ private extension UpdateAppPromptInteractor {
         
         if shouldShowPrompt() {
             switch cloudState {
-            case .enabled(.outOfSync(.schemaNotSupported(let schemaVersion))):
+            case .enabledNotAvailable(reason: .schemaNotSupported(let schemaVersion)):
                 Log("UpdateAppPromptInteractor - iCloud schema not supported detected (v\(schemaVersion)), showing update prompt", module: .interactor)
                 
                 Task { @MainActor in

--- a/2PASS/Data/ModelsTypes/CloudState.swift
+++ b/2PASS/Data/ModelsTypes/CloudState.swift
@@ -26,7 +26,6 @@ public enum CloudState: Equatable {
     public enum Sync: Equatable {
         case syncing
         case synced
-        case outOfSync(OutOfSyncReason)
     }
     
     case unknown
@@ -36,7 +35,7 @@ public enum CloudState: Equatable {
     
     public var hasError: Bool {
         switch self {
-        case .enabled(sync: .outOfSync), .enabledNotAvailable: true
+        case .enabledNotAvailable: true
         default: false
         }
     }
@@ -57,8 +56,7 @@ public enum CloudState: Equatable {
     
     public var isSchemeNotSupported: Bool {
         switch self {
-        case .enabled(sync: .outOfSync(.schemaNotSupported)),
-             .enabledNotAvailable(reason: .schemaNotSupported):
+        case .enabledNotAvailable(reason: .schemaNotSupported):
             return true
         default:
             return false

--- a/2PASS/Data/ModelsTypes/CloudState.swift
+++ b/2PASS/Data/ModelsTypes/CloudState.swift
@@ -17,6 +17,7 @@ public enum CloudState: Equatable {
         case restricted
         case schemaNotSupported(Int)
         case incorrectEncryption
+        case syncNotAllowed
     }
 
     public enum Sync: Equatable {
@@ -50,6 +51,15 @@ public enum CloudState: Equatable {
         }
     }
     
+    public var isSyncNotAllowed: Bool {
+        switch self {
+        case .enabledNotAvailable(reason: .syncNotAllowed):
+            return true
+        default:
+            return false
+        }
+    }
+
     public var isSchemeNotSupported: Bool {
         switch self {
         case .enabledNotAvailable(reason: .schemaNotSupported):

--- a/2PASS/Data/ModelsTypes/CloudState.swift
+++ b/2PASS/Data/ModelsTypes/CloudState.swift
@@ -18,11 +18,7 @@ public enum CloudState: Equatable {
         case schemaNotSupported(Int)
         case incorrectEncryption
     }
-    
-    public enum OutOfSyncReason: Equatable {
-        case schemaNotSupported(Int)
-    }
-    
+
     public enum Sync: Equatable {
         case syncing
         case synced

--- a/2PASS/Data/Repositories/Main/MainRepository.swift
+++ b/2PASS/Data/Repositories/Main/MainRepository.swift
@@ -589,7 +589,7 @@ protocol MainRepository: AnyObject {
     func enableCloudBackup()
     func disableCloudBackup()
     func clearBackup()
-    func synchronizeBackup()
+    func synchronizeBackup(fromPush: Bool)
     func cloudListVaultsToRecover(completion: @escaping (Result<[VaultRawData], Error>) -> Void)
     func cloudDeleteVault(id: VaultID) async throws
     var lastSuccessCloudSyncDate: Date? { get }

--- a/2PASS/Data/Repositories/Main/MainRepository.swift
+++ b/2PASS/Data/Repositories/Main/MainRepository.swift
@@ -551,6 +551,7 @@ protocol MainRepository: AnyObject {
     // MARK: Deleted Items
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
+    func updateDeletedItems(_ items: [DeletedItemData])
     func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData]
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]

--- a/2PASS/Data/Repositories/Main/MainRepository.swift
+++ b/2PASS/Data/Repositories/Main/MainRepository.swift
@@ -552,6 +552,7 @@ protocol MainRepository: AnyObject {
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func deletedItem(id: DeletedItemID) -> DeletedItemData?
+    func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData]
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
     func removeDuplicatedDeletedItems()

--- a/2PASS/Data/Repositories/Main/MainRepository.swift
+++ b/2PASS/Data/Repositories/Main/MainRepository.swift
@@ -446,7 +446,6 @@ protocol MainRepository: AnyObject {
         hidden: Bool
     )
 
-    func updateItems(_ items: [RawItemData])
     func itemsBatchUpdate(_ items: [RawItemData])
     func metadataItemsBatchUpdate(_ items: [any ItemDataType])
     func getItemEntity(

--- a/2PASS/Data/Repositories/Main/MainRepository.swift
+++ b/2PASS/Data/Repositories/Main/MainRepository.swift
@@ -551,9 +551,11 @@ protocol MainRepository: AnyObject {
     // MARK: Deleted Items
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
+    func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
-   
+    func removeDuplicatedDeletedItems()
+
     // MARK: - Web Browser
     func createEncryptedWebBrowser(_ data: WebBrowserEncryptedData)
     func updateEncryptedWebBrowser(_ data: WebBrowserEncryptedData)

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+Cloud.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+Cloud.swift
@@ -30,8 +30,8 @@ extension MainRepositoryImpl {
         cloudSync.clearBackup()
     }
     
-    func synchronizeBackup() {
-        cloudSync.synchronize()
+    func synchronizeBackup(fromPush: Bool = false) {
+        cloudSync.synchronize(fromPush: fromPush)
     }
     
     func cloudListVaultsToRecover(completion: @escaping (Result<[VaultRawData], Error>) -> Void) {

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+Cloud.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+Cloud.swift
@@ -80,6 +80,8 @@ private extension MainRepositoryImpl {
                 return .enabledNotAvailable(reason: .noAccount)
             case .restricted:
                 return .enabledNotAvailable(reason: .restricted)
+            case .syncNotAllowed:
+                return .enabledNotAvailable(reason: .syncNotAllowed)
             }
         case .disabled:
             return .disabled

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
@@ -248,6 +248,10 @@ extension MainRepositoryImpl {
         encryptedStorage.deletedItem(id: id)
     }
 
+    func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData] {
+        encryptedStorage.listDeletedItems(ids: ids)
+    }
+
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         encryptedStorage.listDeletedItems(in: vaultID, limit: limit)
     }

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
@@ -243,7 +243,11 @@ extension MainRepositoryImpl {
         Log("Updating Deleted Item for ItemID: \(id)", module: .mainRepository)
         encryptedStorage.updateDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
     }
-    
+
+    func deletedItem(id: DeletedItemID) -> DeletedItemData? {
+        encryptedStorage.deletedItem(id: id)
+    }
+
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         encryptedStorage.listDeletedItems(in: vaultID, limit: limit)
     }
@@ -252,7 +256,12 @@ extension MainRepositoryImpl {
         Log("Deleting Deleted Item for ItemID: \(id)", module: .mainRepository)
         encryptedStorage.deleteDeletedItem(id: id)
     }
-    
+
+    func removeDuplicatedDeletedItems() {
+        Log("Removing duplicated deleted items", module: .mainRepository)
+        encryptedStorage.removeDuplicatedDeletedItems()
+    }
+
     // MARK: Tags
     
     func createEncryptedTag(_ tag: ItemTagEncryptedData) {

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+EncryptedStorage.swift
@@ -244,6 +244,11 @@ extension MainRepositoryImpl {
         encryptedStorage.updateDeletedItem(id: id, kind: kind, deletedAt: deletedAt, in: vaultID)
     }
 
+    func updateDeletedItems(_ items: [DeletedItemData]) {
+        Log("Bulk updating \(items.count) Deleted Items", module: .mainRepository)
+        encryptedStorage.updateDeletedItems(items)
+    }
+
     func deletedItem(id: DeletedItemID) -> DeletedItemData? {
         encryptedStorage.deletedItem(id: id)
     }

--- a/2PASS/Data/Repositories/Main/MainRepositoryImpl+InMemoryStorage.swift
+++ b/2PASS/Data/Repositories/Main/MainRepositoryImpl+InMemoryStorage.swift
@@ -332,23 +332,6 @@ extension MainRepositoryImpl {
         )
     }
 
-    func updateItems(_ items: [RawItemData]) {
-        items.forEach { item in
-            inMemoryStorage?.updateItem(
-                itemID: item.id,
-                vaultID: item.vaultId,
-                modificationDate: item.modificationDate,
-                trashedStatus: item.trashedStatus,
-                protectionLevel: item.protectionLevel,
-                tagIds: item.tagIds,
-                name: item.name,
-                contentType: item.contentType,
-                contentVersion: item.contentVersion,
-                content: item.content
-            )
-        }
-    }
-    
     func itemsBatchUpdate(_ items: [RawItemData]) {
         inMemoryStorage?.batchUpdateRencryptedItems(items, date: currentDate)
     }

--- a/2PASS/DataTests/Mocks/MockMainRepository.swift
+++ b/2PASS/DataTests/Mocks/MockMainRepository.swift
@@ -2003,6 +2003,18 @@ final class MockMainRepository: MainRepository {
         return self
     }
 
+    private var stubbedListDeletedItemsByIDs: (Set<DeletedItemID>) -> [DeletedItemData] = { _ in [] }
+    func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData] {
+        recordCall()
+        return stubbedListDeletedItemsByIDs(ids)
+    }
+
+    @discardableResult
+    func withListDeletedItemsByIDs(_ handler: @escaping (Set<DeletedItemID>) -> [DeletedItemData]) -> Self {
+        stubbedListDeletedItemsByIDs = handler
+        return self
+    }
+
     private var stubbedListDeletedItems: (VaultID, Int?) -> [DeletedItemData] = { _, _ in [] }
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         recordCall()

--- a/2PASS/DataTests/Mocks/MockMainRepository.swift
+++ b/2PASS/DataTests/Mocks/MockMainRepository.swift
@@ -1991,6 +1991,18 @@ final class MockMainRepository: MainRepository {
         recordCall()
     }
 
+    private var stubbedDeletedItem: (DeletedItemID) -> DeletedItemData? = { _ in nil }
+    func deletedItem(id: DeletedItemID) -> DeletedItemData? {
+        recordCall()
+        return stubbedDeletedItem(id)
+    }
+
+    @discardableResult
+    func withDeletedItem(_ handler: @escaping (DeletedItemID) -> DeletedItemData?) -> Self {
+        stubbedDeletedItem = handler
+        return self
+    }
+
     private var stubbedListDeletedItems: (VaultID, Int?) -> [DeletedItemData] = { _, _ in [] }
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         recordCall()
@@ -2004,6 +2016,10 @@ final class MockMainRepository: MainRepository {
     }
 
     func deleteDeletedItem(id: DeletedItemID) {
+        recordCall()
+    }
+
+    func removeDuplicatedDeletedItems() {
         recordCall()
     }
 

--- a/2PASS/DataTests/Mocks/MockMainRepository.swift
+++ b/2PASS/DataTests/Mocks/MockMainRepository.swift
@@ -1991,6 +1991,10 @@ final class MockMainRepository: MainRepository {
         recordCall()
     }
 
+    func updateDeletedItems(_ items: [DeletedItemData]) {
+        recordCall()
+    }
+
     private var stubbedDeletedItem: (DeletedItemID) -> DeletedItemData? = { _ in nil }
     func deletedItem(id: DeletedItemID) -> DeletedItemData? {
         recordCall()

--- a/2PASS/DataTests/Mocks/MockMainRepository.swift
+++ b/2PASS/DataTests/Mocks/MockMainRepository.swift
@@ -2197,7 +2197,7 @@ final class MockMainRepository: MainRepository {
         recordCall()
     }
 
-    func synchronizeBackup() {
+    func synchronizeBackup(fromPush: Bool) {
         recordCall()
     }
 

--- a/2PASS/DataTests/Mocks/MockMainRepository.swift
+++ b/2PASS/DataTests/Mocks/MockMainRepository.swift
@@ -1658,10 +1658,6 @@ final class MockMainRepository: MainRepository {
         recordCall()
     }
 
-    func updateItems(_ items: [RawItemData]) {
-        recordCall()
-    }
-
     func itemsBatchUpdate(_ items: [RawItemData]) {
         recordCall()
     }

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
@@ -79,9 +79,11 @@ public protocol EncryptedStorageDataSource: AnyObject {
     // MARK: Deleted Items
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
+    func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
-    
+    func removeDuplicatedDeletedItems()
+
     // MARK: Web Browsers
     func createEncryptedWebBrowser(_ data: WebBrowserEncryptedData)
     func updateEncryptedWebBrowser(_ data: WebBrowserEncryptedData)

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
@@ -80,6 +80,7 @@ public protocol EncryptedStorageDataSource: AnyObject {
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func deletedItem(id: DeletedItemID) -> DeletedItemData?
+    func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData]
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]
     func deleteDeletedItem(id: DeletedItemID)
     func removeDuplicatedDeletedItems()

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSource.swift
@@ -79,6 +79,7 @@ public protocol EncryptedStorageDataSource: AnyObject {
     // MARK: Deleted Items
     func createDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
     func updateDeletedItem(id: DeletedItemID, kind: DeletedItemData.Kind, deletedAt: Date, in vaultID: VaultID)
+    func updateDeletedItems(_ items: [DeletedItemData])
     func deletedItem(id: DeletedItemID) -> DeletedItemData?
     func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData]
     func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData]

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
@@ -249,6 +249,11 @@ extension EncryptedStorageDataSourceImpl: EncryptedStorageDataSource {
         DeletedItemEncryptedEntity.getEntity(on: context, itemID: id)?.toData
     }
 
+    public func listDeletedItems(ids: Set<DeletedItemID>) -> [DeletedItemData] {
+        DeletedItemEncryptedEntity.listItems(on: context, itemIDs: ids)
+            .map(\.toData)
+    }
+
     public func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         DeletedItemEncryptedEntity.listItems(on: context, vaultID: vaultID, limit: limit)
             .map({ $0.toData })

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
@@ -245,6 +245,10 @@ extension EncryptedStorageDataSourceImpl: EncryptedStorageDataSource {
         )
     }
 
+    public func updateDeletedItems(_ items: [DeletedItemData]) {
+        DeletedItemEncryptedEntity.bulkUpdate(on: context, items: items)
+    }
+
     public func deletedItem(id: DeletedItemID) -> DeletedItemData? {
         DeletedItemEncryptedEntity.getEntity(on: context, itemID: id)?.toData
     }

--- a/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
+++ b/2PASS/Storage/DataSource/EncryptedStorageDataSourceImpl.swift
@@ -244,7 +244,11 @@ extension EncryptedStorageDataSourceImpl: EncryptedStorageDataSource {
             vaultID: vaultID
         )
     }
-    
+
+    public func deletedItem(id: DeletedItemID) -> DeletedItemData? {
+        DeletedItemEncryptedEntity.getEntity(on: context, itemID: id)?.toData
+    }
+
     public func listDeletedItems(in vaultID: VaultID, limit: Int?) -> [DeletedItemData] {
         DeletedItemEncryptedEntity.listItems(on: context, vaultID: vaultID, limit: limit)
             .map({ $0.toData })
@@ -255,6 +259,10 @@ extension EncryptedStorageDataSourceImpl: EncryptedStorageDataSource {
             return
         }
         DeletedItemEncryptedEntity.delete(on: context, entity: entity)
+    }
+
+    public func removeDuplicatedDeletedItems() {
+        DeletedItemEncryptedEntity.removeDuplicates(on: context)
     }
     
     public func createEncryptedWebBrowser(_ data: WebBrowserEncryptedData) {

--- a/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
+++ b/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
@@ -106,6 +106,26 @@ final class DeletedItemEncryptedEntity: NSManagedObject {
         }
     }
 
+    @nonobjc static func bulkUpdate(
+        on context: NSManagedObjectContext,
+        items: [DeletedItemData]
+    ) {
+        guard !items.isEmpty else { return }
+        let ids = Set(items.map(\.itemID))
+        let entities = listItems(on: context, itemIDs: ids)
+        let entitiesByID = Dictionary(entities.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
+
+        for item in items {
+            guard let entity = entitiesByID[item.itemID] else {
+                Log("Can't find Deleted Password entity for itemID: \(item.itemID)", module: .storage, severity: .error)
+                continue
+            }
+            entity.kind = item.kind.rawValue
+            entity.deletedAt = item.deletedAt
+            entity.vaultID = item.vaultID
+        }
+    }
+
     @nonobjc static func getEntity(
         on context: NSManagedObjectContext,
         itemID: DeletedItemID

--- a/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
+++ b/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
@@ -90,6 +90,22 @@ final class DeletedItemEncryptedEntity: NSManagedObject {
         return list
     }
     
+    @nonobjc static func listItems(
+        on context: NSManagedObjectContext,
+        itemIDs: Set<DeletedItemID>
+    ) -> [DeletedItemEncryptedEntity] {
+        guard !itemIDs.isEmpty else { return [] }
+        let fetchRequest = DeletedItemEncryptedEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "itemID IN %@", itemIDs as CVarArg)
+
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            Log("DeletedItemEncryptedEntity listItems by IDs error: \(error.localizedDescription)", module: .storage)
+            return []
+        }
+    }
+
     @nonobjc static func getEntity(
         on context: NSManagedObjectContext,
         itemID: DeletedItemID

--- a/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
+++ b/2PASS/Storage/Encrypted/DeletedItemEncryptedEntity.swift
@@ -126,6 +126,34 @@ final class DeletedItemEncryptedEntity: NSManagedObject {
         Log("Deleting entity of type: \(entity)", module: .storage)
         context.delete(entity)
     }
+
+    @nonobjc static func removeDuplicates(on context: NSManagedObjectContext) {
+        let fetchRequest = DeletedItemEncryptedEntity.fetchRequest()
+        fetchRequest.sortDescriptors = [
+            NSSortDescriptor(
+                key: #keyPath(DeletedItemEncryptedEntity.deletedAt),
+                ascending: false,
+                selector: #selector(NSDate.compare)
+            )
+        ]
+
+        let allItems: [DeletedItemEncryptedEntity]
+        do {
+            allItems = try context.fetch(fetchRequest)
+        } catch {
+            Log("DeletedItemEncryptedEntity removeDuplicates fetch error: \(error.localizedDescription)", module: .storage)
+            return
+        }
+
+        var seenIDs: Set<DeletedItemID> = []
+        for item in allItems {
+            if seenIDs.contains(item.itemID) {
+                delete(on: context, entity: item)
+            } else {
+                seenIDs.insert(item.itemID)
+            }
+        }
+    }
 }
 
 extension DeletedItemEncryptedEntity {


### PR DESCRIPTION
Fix iCloud sync: deleted items handling, multi-device race conditions, and device ID takeover

Deleted items deduplication & batch operations
- Fix duplicate deleted items created during iCloud sync by deduplicating entries in MergeHandler.mergeDeletedItems (keep latest date)
- Add batch createDeletedItems / updateDeletedItems to LocalStorage and EncryptedStorageDataSource
- Centralize deleted-item existence checks in DeletedItemsInteractor
- Remove duplicated deleted items on app update via migration

Multi-device sync race condition fixes
- Fix race condition where batch deletions on one device could be undone by another device re-uploading items — deletion now wins on equal timestamps
- Handle cloud deleted records for items/tags that were already resolved (matched in merge) but still need local trash operations
- Clean up local-only deleted/item/tag records from CloudKit during prepareChangesForRemoval

CloudKit batching rework (ModificationBatchQueue)
- Rework batching to send modifications first, then deletions within the same batch (prevents re-upload of deleted records)
- Combine modify + delete into unified batches instead of separate queues

Sync handler improvements
- Allow cancellation of pending retry when a new sync is triggered
- Queue re-sync when a push notification arrives during an in-progress sync (needsResync flag)
- Fix isSyncing state not being reset on noLocalVault/mergeError errors

Device ID & vault takeover
- Fix device ID takeover in iCloud by adding isTakingOverVault flag to MergeHandler
- Replace random/fixed retry delays with deterministic stepped backoff in CloudKitErrorParser

Other fixes
- Fix MergeHandler.clear() not resetting tags, tagForRemoval, and recordItemIDsForDeletition
- Fix CacheHandler not updating metadata when server records have same modification date
- Fix notification kind for reload items list
- Fix fallback on logout during iCloud sync
- Fix update prompt for unsupported schema
- Add bulk move-to-trash in multi-select (passwords module)
- Change tag color now updates modification date
- Always show badge on iCloud sync error; model sync-not-allowed as enabledNotAvailable state